### PR TITLE
Fix admin delete user

### DIFF
--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminUserController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminUserController.java
@@ -3,6 +3,7 @@ package garlicbears.quiz.domain.management.admin.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,7 +34,7 @@ public class AdminUserController implements SwaggerAdminUserController {
 	// 유저 삭제
 	@DeleteMapping("/{userId}")
 	public ResponseEntity<?> deleteUser(
-		@RequestParam(value = "userId") long userId
+		@PathVariable(value = "userId") long userId
 	) {
 		adminUserService.delete(userId);
 		return ResponseEntity.ok().build();

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminUserController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminUserController.java
@@ -1,6 +1,7 @@
 package garlicbears.quiz.domain.management.admin.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import garlicbears.quiz.domain.management.admin.dto.ResponseUserListDto;
@@ -34,6 +35,6 @@ public interface SwaggerAdminUserController {
 			content = {@Content(schema = @Schema(implementation = ResponseDto.class))})
 	})
 	public ResponseEntity<?> deleteUser(
-		@RequestParam(value = "userId") long userId
+		@PathVariable(value = "userId") long userId
 	);
 }


### PR DESCRIPTION
관리자의 유저 삭제 기능에서 /admin/user/{userId} 로 정의를 해두었는데
컨트롤러에서 /admin/user/{userId}?userId=value 형식으로 처리가 되고있는 부분을 확인하여 수정하였습니다.