### PR TITLE
Fix admin delete 관리자 관리 기능 오류 수정

### DIFF
--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -56,7 +57,7 @@ public class AdminController implements SwaggerAdminController {
 	 * 관리자 삭제
 	 */
 	@DeleteMapping("/delete/{adminId}")
-	public ResponseEntity<?> deleteAdmin(@RequestParam(value = "adminId") long adminId) {
+	public ResponseEntity<?> deleteAdmin(@PathVariable long adminId) {
 		adminService.delete(adminId);
 		return ResponseEntity.ok(ResponseDto.success());
 	}

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -53,6 +54,6 @@ public interface SwaggerAdminController {
 			content = {@Content(schema = @Schema(implementation = ResponseDto.class))})
 	})
 	public ResponseEntity<?> deleteAdmin(
-		@RequestParam(value = "adminId") long adminId
+		@PathVariable long adminId
 	);
 }

--- a/src/main/java/garlicbears/quiz/domain/management/admin/dto/ResponseAdminDto.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/dto/ResponseAdminDto.java
@@ -1,16 +1,23 @@
 package garlicbears.quiz.domain.management.admin.dto;
 
+import java.time.LocalDateTime;
+
 import garlicbears.quiz.domain.common.entity.Active;
 
 public class ResponseAdminDto {
 	private long adminId;
 	private String adminEmail;
 	private String adminActive;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 
-	public ResponseAdminDto(long adminId, String adminEmail, Active adminActive) {
+	public ResponseAdminDto(long adminId, String adminEmail, Active adminActive,
+		LocalDateTime createdAt, LocalDateTime updatedAt) {
 		this.adminId = adminId;
 		this.adminEmail = adminEmail;
 		this.adminActive = adminActive.name();
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
 	}
 
 	public long getAdminId() {
@@ -23,5 +30,13 @@ public class ResponseAdminDto {
 
 	public String getAdminActive() {
 		return adminActive;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public LocalDateTime getUpdatedAt() {
+		return updatedAt;
 	}
 }

--- a/src/main/java/garlicbears/quiz/domain/management/admin/repository/AdminQueryRepositoryImpl.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/repository/AdminQueryRepositoryImpl.java
@@ -37,7 +37,9 @@ public class AdminQueryRepositoryImpl implements AdminQueryRepository {
 			.select(Projections.constructor(ResponseAdminDto.class,
 				admin.adminId,
 				admin.adminEmail,
-				admin.active
+				admin.active,
+				admin.createdAt,
+				admin.updatedAt
 			))
 			.from(admin)
 			.orderBy(getOrderSpecifier(admin, sortBy))


### PR DESCRIPTION
관리자 조회 시 생성일, 수정일이 반환되지 않아 해당 부분 추가하였습니다.
관리자 삭제 시 이전 토픽 삭제 오류처럼 /api/admin/{adminId}?adminId=value 형식으로 동작해 해당 부분 수정하였습니다.