### PR TITLE
Gb 95 admin list admin role update

### DIFF
--- a/src/main/java/garlicbears/quiz/domain/common/entity/Admin.java
+++ b/src/main/java/garlicbears/quiz/domain/common/entity/Admin.java
@@ -120,4 +120,8 @@ public class Admin extends BaseTimeEntity implements UserDetails {
 	public void setActive(Active active) {
 		this.active = active;
 	}
+
+	public void setRoles(Role role) {
+		this.roles.add(role);
+	}
 }

--- a/src/main/java/garlicbears/quiz/domain/common/entity/Admin.java
+++ b/src/main/java/garlicbears/quiz/domain/common/entity/Admin.java
@@ -121,7 +121,12 @@ public class Admin extends BaseTimeEntity implements UserDetails {
 		this.active = active;
 	}
 
-	public void setRoles(Role role) {
+	public void addRole(Role role) {
 		this.roles.add(role);
+	}
+
+	// 필요한 경우, 여러 역할을 한 번에 설정하는 메서드
+	public void setRoles(Set<Role> roles) {
+		this.roles = roles;
 	}
 }

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
@@ -9,6 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,8 +20,10 @@ import org.springframework.web.bind.annotation.RestController;
 import garlicbears.quiz.domain.common.dto.ResponseDto;
 import garlicbears.quiz.domain.common.entity.Admin;
 import garlicbears.quiz.domain.common.entity.Role;
+import garlicbears.quiz.domain.management.admin.dto.RequestChangeRoleDto;
 import garlicbears.quiz.domain.management.admin.service.AdminService;
 import garlicbears.quiz.domain.management.common.dto.LoginDto;
+import garlicbears.quiz.domain.management.common.repository.RoleRepository;
 import garlicbears.quiz.global.exception.CustomException;
 import garlicbears.quiz.global.exception.ErrorCode;
 import garlicbears.quiz.global.jwt.service.RefreshTokenService;
@@ -41,15 +44,18 @@ public class AdminController implements SwaggerAdminController {
 	private final JwtTokenizer jwtTokenizer;
 	private final PasswordEncoder passwordEncoder;
 	private final RefreshTokenService refreshTokenService;
+	private final RoleRepository roleRepository;
 
 	public AdminController(AdminService adminService,
 		JwtTokenizer jwtTokenizer,
 		PasswordEncoder passwordEncoder,
-		RefreshTokenService refreshTokenService) {
+		RefreshTokenService refreshTokenService,
+		RoleRepository roleRepository) {
 		this.adminService = adminService;
 		this.jwtTokenizer = jwtTokenizer;
 		this.passwordEncoder = passwordEncoder;
 		this.refreshTokenService = refreshTokenService;
+		this.roleRepository = roleRepository;
 	}
 
 	/**
@@ -196,10 +202,13 @@ public class AdminController implements SwaggerAdminController {
 	 * 관리자 권한 변경
 	 */
 	@Override
-	// @PatchMapping("/changeRole/{adminId}")
-	public ResponseEntity<?> changeAdminRole(@RequestParam(value = "adminId") long adminId) {
-		// TODO JWT 토큰이 완성되면 구현
-		return null;
+	@PatchMapping("/changeRole")
+	public ResponseEntity<?> changeAdminRole(@Valid @RequestBody RequestChangeRoleDto requestChangeRoleDto) {
+		Admin admin = adminService.findById(requestChangeRoleDto.getAdminId());
+		Role adminRole = roleRepository.findByRoleName(requestChangeRoleDto.getRole())
+			.orElseThrow(() -> new CustomException(ErrorCode.ROLE_NOT_FOUND));
+		adminService.updateRole(admin, adminRole);
+		return ResponseEntity.ok(ResponseDto.success());
 	}
 
 	/**

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
@@ -24,6 +24,7 @@ import garlicbears.quiz.domain.management.admin.dto.RequestChangeRoleDto;
 import garlicbears.quiz.domain.management.admin.service.AdminService;
 import garlicbears.quiz.domain.management.common.dto.LoginDto;
 import garlicbears.quiz.domain.management.common.repository.RoleRepository;
+import garlicbears.quiz.domain.management.common.sevice.RoleService;
 import garlicbears.quiz.global.exception.CustomException;
 import garlicbears.quiz.global.exception.ErrorCode;
 import garlicbears.quiz.global.jwt.service.RefreshTokenService;
@@ -44,18 +45,18 @@ public class AdminController implements SwaggerAdminController {
 	private final JwtTokenizer jwtTokenizer;
 	private final PasswordEncoder passwordEncoder;
 	private final RefreshTokenService refreshTokenService;
-	private final RoleRepository roleRepository;
+	private final RoleService roleService;
 
 	public AdminController(AdminService adminService,
 		JwtTokenizer jwtTokenizer,
 		PasswordEncoder passwordEncoder,
 		RefreshTokenService refreshTokenService,
-		RoleRepository roleRepository) {
+		RoleService roleService) {
 		this.adminService = adminService;
 		this.jwtTokenizer = jwtTokenizer;
 		this.passwordEncoder = passwordEncoder;
 		this.refreshTokenService = refreshTokenService;
-		this.roleRepository = roleRepository;
+		this.roleService = roleService;
 	}
 
 	/**
@@ -205,8 +206,7 @@ public class AdminController implements SwaggerAdminController {
 	@PatchMapping("/changeRole")
 	public ResponseEntity<?> changeAdminRole(@Valid @RequestBody RequestChangeRoleDto requestChangeRoleDto) {
 		Admin admin = adminService.findById(requestChangeRoleDto.getAdminId());
-		Role adminRole = roleRepository.findByRoleName(requestChangeRoleDto.getRoleName())
-			.orElseThrow(() -> new CustomException(ErrorCode.ROLE_NOT_FOUND));
+		Role adminRole = roleService.findByRoleName(requestChangeRoleDto.getRoleName());
 		adminService.updateRole(admin, adminRole);
 		return ResponseEntity.ok(ResponseDto.success());
 	}

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/AdminController.java
@@ -205,7 +205,7 @@ public class AdminController implements SwaggerAdminController {
 	@PatchMapping("/changeRole")
 	public ResponseEntity<?> changeAdminRole(@Valid @RequestBody RequestChangeRoleDto requestChangeRoleDto) {
 		Admin admin = adminService.findById(requestChangeRoleDto.getAdminId());
-		Role adminRole = roleRepository.findByRoleName(requestChangeRoleDto.getRole())
+		Role adminRole = roleRepository.findByRoleName(requestChangeRoleDto.getRoleName())
 			.orElseThrow(() -> new CustomException(ErrorCode.ROLE_NOT_FOUND));
 		adminService.updateRole(admin, adminRole);
 		return ResponseEntity.ok(ResponseDto.success());

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
@@ -1,32 +1,65 @@
 package garlicbears.quiz.domain.management.admin.controller;
 
-import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import garlicbears.quiz.domain.common.dto.ResponseDto;
-import garlicbears.quiz.domain.management.admin.dto.AdminSignUpDto;
 import garlicbears.quiz.domain.management.admin.dto.RequestChangeRoleDto;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminDto;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminListDto;
+import garlicbears.quiz.domain.management.common.dto.LoginDto;
+import garlicbears.quiz.domain.management.common.dto.ResponseUserDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 public interface SwaggerAdminController {
+	@Operation(summary = "관리자 로그인", description = "email, password를 입력 받아 로그인을 시도합니다.")
+	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Successfully retrieved", content = {
+		@Content(schema = @Schema(implementation = ResponseUserDto.class))}),
+		@ApiResponse(responseCode = "400", description = "Invalid input",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "401", description = "Unauthorized",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
+	public ResponseEntity<?> login(@Valid @RequestBody LoginDto loginDto, BindingResult bindingResult,
+		HttpServletResponse response);
+
+	@Operation(summary = "Reissue Token", description = "Access Token 만료 시 재발급")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Successfully retrieved",
+			content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+		@ApiResponse(responseCode = "400", description = "Invalid refresh token",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "401", description = "Unauthorized",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
+	@GetMapping("/reissue")
+	public ResponseEntity<?> requestRefresh(HttpServletRequest request, HttpServletResponse response);
+
+	@Operation(summary = "관리자 로그아웃", description = "로그아웃 처리")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+		@ApiResponse(responseCode = "400", description = "Invalid request"),
+		@ApiResponse(responseCode = "500", description = "Internal server error")})
+	@DeleteMapping("/logout")
+	public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response);
+
 	@Operation(summary = "관리자 목록 조회", description = "정렬 기준에 따라 관리자 목록을 반환합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Successfully retrieved",
 			content = {@Content(schema = @Schema(implementation = ResponseAdminListDto.class))}),
-		@ApiResponse(responseCode = "403", description = "Forbidden (Invalid token)")
+		@ApiResponse(responseCode = "401", description = "Unauthorized (Invalid token)")
 	})
 	public ResponseEntity<?> listAdmins(
 		@RequestParam(defaultValue = "createdAtDesc") String sort,
@@ -38,7 +71,7 @@ public interface SwaggerAdminController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Successfully retrieved",
 			content = {@Content(schema = @Schema(implementation = ResponseAdminDto.class))}),
-		@ApiResponse(responseCode = "403", description = "Forbidden (Invalid token)"),
+		@ApiResponse(responseCode = "401", description = "Unauthorized (Invalid token)"),
 		@ApiResponse(responseCode = "404", description = "Not Found (Admin not found)")
 	})
 	public ResponseEntity<?> changeAdminRole(

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
@@ -71,8 +71,9 @@ public interface SwaggerAdminController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "Successfully retrieved",
 			content = {@Content(schema = @Schema(implementation = ResponseAdminDto.class))}),
+		@ApiResponse(responseCode = "400", description = "BAD REQUEST (Missing request body variable)"),
 		@ApiResponse(responseCode = "401", description = "Unauthorized (Invalid token)"),
-		@ApiResponse(responseCode = "404", description = "Not Found (Admin not found)")
+		@ApiResponse(responseCode = "404", description = "Not Found (Role Not Found)")
 	})
 	public ResponseEntity<?> changeAdminRole(
 		@Valid @RequestBody RequestChangeRoleDto requestChangeRoleDto

--- a/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/controller/SwaggerAdminController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import garlicbears.quiz.domain.common.dto.ResponseDto;
 import garlicbears.quiz.domain.management.admin.dto.AdminSignUpDto;
+import garlicbears.quiz.domain.management.admin.dto.RequestChangeRoleDto;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminDto;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminListDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,7 +42,7 @@ public interface SwaggerAdminController {
 		@ApiResponse(responseCode = "404", description = "Not Found (Admin not found)")
 	})
 	public ResponseEntity<?> changeAdminRole(
-		@RequestParam(value = "adminId") long adminId
+		@Valid @RequestBody RequestChangeRoleDto requestChangeRoleDto
 	);
 
 	@Operation(summary = "관리자 삭제", description = "입력된 관리자를 삭제합니다.")

--- a/src/main/java/garlicbears/quiz/domain/management/admin/dto/RequestChangeRoleDto.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/dto/RequestChangeRoleDto.java
@@ -7,10 +7,10 @@ public class RequestChangeRoleDto {
 	@NotNull
 	long adminId;
 	@NotNull
-	String role;
+	String roleName;
 
-	public String getRole() {
-		return role;
+	public String getRoleName() {
+		return roleName;
 	}
 
 	public long getAdminId(){
@@ -21,8 +21,8 @@ public class RequestChangeRoleDto {
 
 	}
 
-	public RequestChangeRoleDto(long adminId, String role) {
+	public RequestChangeRoleDto(long adminId, String roleName) {
 		this.adminId = adminId;
-		this.role = role;
+		this.roleName = roleName;
 	}
 }

--- a/src/main/java/garlicbears/quiz/domain/management/admin/dto/RequestChangeRoleDto.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/dto/RequestChangeRoleDto.java
@@ -1,0 +1,28 @@
+package garlicbears.quiz.domain.management.admin.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public class RequestChangeRoleDto {
+	@NotNull
+	long adminId;
+	@NotNull
+	String role;
+
+	public String getRole() {
+		return role;
+	}
+
+	public long getAdminId(){
+		return adminId;
+	}
+
+	public RequestChangeRoleDto(){
+
+	}
+
+	public RequestChangeRoleDto(long adminId, String role) {
+		this.adminId = adminId;
+		this.role = role;
+	}
+}

--- a/src/main/java/garlicbears/quiz/domain/management/admin/dto/ResponseAdminDto.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/dto/ResponseAdminDto.java
@@ -2,6 +2,7 @@ package garlicbears.quiz.domain.management.admin.dto;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import garlicbears.quiz.domain.common.entity.Active;
 
@@ -12,13 +13,16 @@ public class ResponseAdminDto {
 	private String createdAt;
 	private String updatedAt;
 
+	private List<String> adminRole;
+
 	public ResponseAdminDto(long adminId, String adminEmail, Active adminActive,
-		LocalDateTime createdAt, LocalDateTime updatedAt) {
+		LocalDateTime createdAt, LocalDateTime updatedAt, List<String> adminRole) {
 		this.adminId = adminId;
 		this.adminEmail = adminEmail;
 		this.adminActive = adminActive.name();
 		this.createdAt = createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 		this.updatedAt = updatedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+		this.adminRole = adminRole;
 	}
 
 	public long getAdminId() {
@@ -39,5 +43,9 @@ public class ResponseAdminDto {
 
 	public String getUpdatedAt() {
 		return updatedAt;
+	}
+
+	public List<String> getAdminRole() {
+		return adminRole;
 	}
 }

--- a/src/main/java/garlicbears/quiz/domain/management/admin/repository/AdminQueryRepositoryImpl.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/repository/AdminQueryRepositoryImpl.java
@@ -1,16 +1,19 @@
 package garlicbears.quiz.domain.management.admin.repository;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import garlicbears.quiz.domain.common.entity.QAdmin;
+import garlicbears.quiz.domain.common.entity.QRole;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminDto;
 import jakarta.persistence.EntityManager;
 
@@ -32,20 +35,23 @@ public class AdminQueryRepositoryImpl implements AdminQueryRepository {
 	@Override
 	public Page<ResponseAdminDto> findAdmins(int page, int size, String sortBy, Pageable pageable) {
 		QAdmin admin = QAdmin.admin;
+		QRole role = QRole.role;
 
 		List<ResponseAdminDto> results = queryFactory
-			.select(Projections.constructor(ResponseAdminDto.class,
-				admin.adminId,
-				admin.adminEmail,
-				admin.active,
-				admin.createdAt,
-				admin.updatedAt
-			))
 			.from(admin)
+			.leftJoin(admin.roles,role)
 			.orderBy(getOrderSpecifier(admin, sortBy))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.fetch();
+			.transform(GroupBy.groupBy(admin.adminId).list(
+				Projections.constructor(ResponseAdminDto.class,
+					admin.adminId,
+					admin.adminEmail,
+					admin.active,
+					admin.createdAt,
+					admin.updatedAt,
+					GroupBy.list(role.roleName))
+			));
 
 		Long total = queryFactory
 			.select(admin.count())

--- a/src/main/java/garlicbears/quiz/domain/management/admin/service/AdminService.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/service/AdminService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import garlicbears.quiz.domain.common.entity.Active;
 import garlicbears.quiz.domain.common.entity.Admin;
 
+import garlicbears.quiz.domain.common.entity.Role;
 import garlicbears.quiz.domain.common.repository.AdminRepository;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminDto;
 import garlicbears.quiz.domain.management.admin.dto.ResponseAdminListDto;
@@ -46,6 +47,18 @@ public class AdminService {
 		Admin admin = adminRepository.findById(adminId)
 			.orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
 		admin.setActive(Active.inactive);
+		adminRepository.save(admin);
+	}
+
+	@Transactional
+	public Admin findById(long adminId) {
+		return adminRepository.findById(adminId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ADMIN_NOT_FOUND));
+	}
+
+	@Transactional
+	public void updateRole(Admin admin, Role role) {
+		admin.setRoles(role);
 		adminRepository.save(admin);
 	}
 }

--- a/src/main/java/garlicbears/quiz/domain/management/admin/service/AdminService.java
+++ b/src/main/java/garlicbears/quiz/domain/management/admin/service/AdminService.java
@@ -1,5 +1,7 @@
 package garlicbears.quiz.domain.management.admin.service;
 
+import java.util.Iterator;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -57,8 +59,22 @@ public class AdminService {
 	}
 
 	@Transactional
-	public void updateRole(Admin admin, Role role) {
-		admin.setRoles(role);
+	public void updateRole(Admin admin, Role newRole) {
+
+		// ROLE_ADMIN 제외한 모든 역할 제거
+		// Iterator : 컬렉션 객체의 요소를 순차적으로 접근하고 반복하는 데 사용되는 인터페이스
+		// admin.getRoles().removeIf(role -> !role.getRoleName().equals("ROLE_ADMIN"));
+		Iterator<Role> iterator = admin.getRoles().iterator();
+		while(iterator.hasNext()) {
+			Role role = iterator.next();
+			if(!role.getRoleName().equals("ROLE_ADMIN")) {
+				iterator.remove();
+			}
+		}
+
+		// 새로운 역할 추가
+		admin.addRole(newRole);
+
 		adminRepository.save(admin);
 	}
 }

--- a/src/main/java/garlicbears/quiz/domain/management/common/sevice/RoleService.java
+++ b/src/main/java/garlicbears/quiz/domain/management/common/sevice/RoleService.java
@@ -1,0 +1,22 @@
+package garlicbears.quiz.domain.management.common.sevice;
+
+import org.springframework.stereotype.Service;
+
+import garlicbears.quiz.domain.common.entity.Role;
+import garlicbears.quiz.domain.management.common.repository.RoleRepository;
+import garlicbears.quiz.global.exception.CustomException;
+import garlicbears.quiz.global.exception.ErrorCode;
+
+@Service
+public class RoleService {
+	private final RoleRepository roleRepository;
+
+	public RoleService(RoleRepository roleRepository) {
+		this.roleRepository = roleRepository;
+	}
+
+	public Role findByRoleName(String roleName) {
+		return roleRepository.findByRoleName(roleName)
+			.orElseThrow(() -> new CustomException(ErrorCode.ROLE_NOT_FOUND));
+	}
+}

--- a/src/main/java/garlicbears/quiz/domain/management/user/controller/SwaggerUserController.java
+++ b/src/main/java/garlicbears/quiz/domain/management/user/controller/SwaggerUserController.java
@@ -6,9 +6,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import garlicbears.quiz.domain.common.dto.ResponseDto;
+import garlicbears.quiz.domain.management.common.dto.LoginDto;
 import garlicbears.quiz.domain.management.common.dto.ResponseUserDto;
 import garlicbears.quiz.domain.management.user.dto.SignUpDto;
 import garlicbears.quiz.domain.management.user.dto.UpdateUserDto;
@@ -19,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 public interface SwaggerUserController {
@@ -79,4 +84,33 @@ public interface SwaggerUserController {
 			@Content(schema = @Schema(implementation = ResponseDto.class))})})
 	public ResponseEntity<?> rating(@AuthenticationPrincipal UserDetails userDetails,
 		@RequestBody Map<String, Double> request);
+
+	@Operation(summary = "로그인", description = "email, password를 입력 받아 로그인을 시도합니다.")
+		@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Successfully retrieved", content = {
+			@Content(schema = @Schema(implementation = ResponseUserDto.class))}),
+			@ApiResponse(responseCode = "400", description = "Invalid input",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(responseCode = "401", description = "Unauthorized",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
+	public ResponseEntity<?> login(@Valid @RequestBody LoginDto loginDto, BindingResult bindingResult,
+		HttpServletResponse response);
+
+	@Operation(summary = "Reissue Token", description = "Access Token 만료 시 재발급")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Successfully retrieved",
+			content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+		@ApiResponse(responseCode = "400", description = "Invalid refresh token",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "401", description = "Unauthorized",
+			content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
+	@GetMapping("/reissue")
+	public ResponseEntity<?> requestRefresh(HttpServletRequest request, HttpServletResponse response);
+
+	@Operation(summary = "로그아웃", description = "로그아웃 처리")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+		@ApiResponse(responseCode = "400", description = "Invalid request"),
+		@ApiResponse(responseCode = "500", description = "Internal server error")})
+	@DeleteMapping("/logout")
+	public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/garlicbears/quiz/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/garlicbears/quiz/global/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package garlicbears.quiz.global.handler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,6 +13,8 @@ import garlicbears.quiz.global.exception.ErrorCode;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
+	private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
 	/**
 	 * CustomException을 처리하는 핸들러
 	 */
@@ -19,6 +23,10 @@ public class GlobalExceptionHandler {
 		ErrorCode errorCode = e.getErrorCode();
 		ResponseDto<String> response = new ResponseDto<>(errorCode.getStatus().value(),
 			errorCode.toString());
+
+		// 예외 메시지를 로그로 기록
+		logger.error("CustomException occurred: {}", errorCode, e);
+
 		return new ResponseEntity<>(response, errorCode.getStatus());
 	}
 
@@ -28,7 +36,12 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(NullPointerException.class)
 	public ResponseEntity<ResponseDto<String>> handleNullPointerException(NullPointerException e) {
 		ErrorCode errorCode = ErrorCode.MISSING_REQUEST_BODY_VARIABLE;
-		ResponseDto<String> response = new ResponseDto<>(errorCode.getStatus().value(), errorCode.toString());
+		ResponseDto<String> response = new ResponseDto<>(errorCode.getStatus().value(),
+			errorCode.toString());
+
+		// 예외 메시지를 로그로 기록
+		logger.error("NullPointerException occurred: {}", e.getMessage(), e);
+
 		return new ResponseEntity<>(response, errorCode.getStatus());
 	}
 }


### PR DESCRIPTION
1. 관리자 목록에서 각 관리자의 역할(role)을 표시하는 기능을 추가

2. 관리자 역할을 변경할 수 있는 기능을 구현 (Swagger 수정)

    - ROLE_ADMIN을 제외한 다른 역할이 기존에 할당되어 있는 경우, 해당 역할을 삭제하고 새로운 역할로 업데이트합니다.

3. 유저 및 관리자 로그인, 로그아웃, 토큰 재발급 Swagger 추가
